### PR TITLE
Fix toast timeout and import path

### DIFF
--- a/src/components/preference-display-card.tsx
+++ b/src/components/preference-display-card.tsx
@@ -1,4 +1,4 @@
-import type { RestaurantCriteria } from "@/app/actions";
+import type { RestaurantCriteria } from "@/lib/schemas";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CalendarDays, Clock, DollarSign, MapPin, Utensils } from "lucide-react";
 

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -9,7 +9,9 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Toasts were lingering for over 15 minutes due to an excessive delay.
+// Ten seconds is ample time for users to read the message.
+const TOAST_REMOVE_DELAY = 10000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- shorten toast removal delay to 10 seconds
- import `RestaurantCriteria` from the schemas module

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6846ea58b6508324a74dd961353d11c6